### PR TITLE
Make showmore functional [OP-82]

### DIFF
--- a/app/components/layer-wiki/component.js
+++ b/app/components/layer-wiki/component.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
     session: Ember.inject.service(),
     currentWiki: null,
     showSelect: false,
+    isTruncated: false,
     reloadWiki: Ember.computed('layer.settings.wikiId', function(){
         this.get('node.wikis').then(()=>{
             if(!this.get('layers.settings.wikiID')){
@@ -73,6 +74,9 @@ export default Ember.Component.extend({
             this.loadCurrentWiki();
             this.set('showSelect', false);
 
+        },
+        toggleShow(){
+            this.toggleProperty('isTruncated');
         }
     }
 });

--- a/app/components/layer-wiki/style.scss
+++ b/app/components/layer-wiki/style.scss
@@ -1,3 +1,26 @@
 .wiki-markdown {
     overflow: auto;
+    &.truncated {
+        height: 400px;
+    }
+}
+
+.show-more {
+    position: relative;
+    cursor: pointer;
+    border-bottom: 1px dotted #ccc;
+    font-size: 14px;
+    text-align: center;
+    padding-top: 18px;
+    color: #666;
+    &.truncated {
+        margin-top: -25px;
+        box-shadow: inset 0 -35px 20px 4px #fff;
+    }
+    .material-icons {
+        vertical-align: middle;
+    }
+    &:hover {
+        color: #000;
+    }
 }

--- a/app/components/layer-wiki/template.hbs
+++ b/app/components/layer-wiki/template.hbs
@@ -1,9 +1,20 @@
 <div class="">
     {{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.values.alignment}}
 
-    <div class="wiki-markdown">
+    <div class="wiki-markdown {{if (and isTruncated layer.settings.values.addShowMore) 'truncated'}} ">
         {{markdown-to-html layer.wikiContent}}
     </div>
+    {{#if layer.settings.values.addShowMore}}
+        <div class="show-more {{if isTruncated 'truncated'}}" {{action 'toggleShow'}}>
+            {{#if isTruncated}}
+                <i class="material-icons ">keyboard_arrow_down</i>
+                <span>Show more</span>
+            {{else}}
+                <i class="material-icons">keyboard_arrow_up</i>
+                <span>Show less</span>
+            {{/if}}
+        </div>
+    {{/if}}
 
     {{#if editMode}}
         {{#if showSelect}}
@@ -26,12 +37,5 @@
                 </p>
             </div>
         {{/if}}
-    {{/if}}
-
-
-    {{#if layer.settings.values.addShowMore}}
-        <div class="show-more">
-            Show more
-        </div>
     {{/if}}
 </div>


### PR DESCRIPTION
We had so far a placeholder for the show more functionality, this PR adds it to the wiki pages. 

It does not implement checking of whether the page is long enough to truncate because the product might evolve to provide different options to the user. 