### PR TITLE
Refactor settings data [OP-109]

### DIFF
--- a/app/components/edit-text/template.hbs
+++ b/app/components/edit-text/template.hbs
@@ -1,15 +1,15 @@
 {{#if (eq type 'title')}}
     {{#if editMode}}
-        {{input class=layer.settings.values.alignment maxlength=140 value=layer.settings.values.sectionTitle }}
+        {{input class=layer.settings.alignment maxlength=140 value=layer.settings.sectionTitle }}
     {{else}}
-        <div class="{{layer.settings.values.alignment}}-title"><h2>{{layer.settings.values.sectionTitle}}</h2></div>
+        <div class="{{layer.settings.alignment}}-title"><h2>{{layer.settings.sectionTitle}}</h2></div>
     {{/if}}
 {{else}}
 	{{#if editMode}}
-		{{quill-editor value=layer.content.settings.values.sectionDescription options=options textChange=(action "updateText")}}
+		{{quill-editor value=layer.content.settings.sectionDescription options=options textChange=(action "updateText")}}
 	{{else}}
 	<div  class="ql-editor">
-		{{{layer.content.settings.values.sectionDescription}}}
+		{{{layer.content.settings.sectionDescription}}}
 	</div>
 	{{/if}}
 {{/if}}

--- a/app/components/layer-file/component.js
+++ b/app/components/layer-file/component.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
     showSelect: false,
     noFileFound: true,
     didRender() {
-        if(!this.get('layer.settings.values.downloadLink')){
+        if(!this.get('layer.settings.downloadLink')){
             this.get('node.files').then((result)=>{
                 result.objectAt(0).get('files').then((files)=>{
                     if(files.length === 0){
@@ -18,9 +18,9 @@ export default Ember.Component.extend({
                     for(let i = 0; i < files.length; i++){
                         fileModifiedDates.push(files.objectAt(i).get('dateModified'));
                         fileDatesLinks[files.objectAt(i).get('dateModified')] = files.objectAt(i).get('links').download;
-                    }                
+                    }
                     let mostRecentDate = new Date(Math.max.apply(null,fileModifiedDates));
-                    this.set('layer.settings.values.downloadLink' , fileDatesLinks[mostRecentDate]);
+                    this.set('layer.settings.downloadLink' , fileDatesLinks[mostRecentDate]);
                 });
             });
         }else{
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
     actions: {
         fileDetail(file) {
             this.set('showSelect', false);
-            this.set('layer.settings.values.downloadLink' ,  file.data.links.download)
+            this.set('layer.settings.downloadLink' ,  file.data.links.download)
         },
         showSelect(){
             this.set('showSelect', true);

--- a/app/components/layer-file/template.hbs
+++ b/app/components/layer-file/template.hbs
@@ -21,7 +21,7 @@
             {{else}}
                 <div class="select-box p-v-md" {{action 'showSelect'}}>
                     <p>
-                        {{#if layer.settings.values.downloadLink}}
+                        {{#if layer.settings.downloadLink}}
                             Change selection
                         {{else}}
                             Select a file
@@ -33,20 +33,20 @@
     {{/if}}
 
 
-    {{#if layer.settings.values.showFileviewer}}
+    {{#if layer.settings.showFileviewer}}
         <div class="m-v-lg">
-            {{#if layer.settings.values.downloadLink}}
-                {{file-renderer download=layer.settings.values.downloadLink width="100%" height="1000" allowfullscreen=true}}
+            {{#if layer.settings.downloadLink}}
+                {{file-renderer download=layer.settings.downloadLink width="100%" height="1000" allowfullscreen=true}}
             {{/if}}
         </div>
     {{/if}}
 
-    {{#if layer.settings.values.showDownload}}
+    {{#if layer.settings.showDownload}}
         {{#if editMode}}
-         <a class="btn pull-right btn-info btn-outline-cus btn-lg" style="color:#5bc0de">{{input value=layer.settings.values.buttonText }}
+         <a class="btn pull-right btn-info btn-outline-cus btn-lg" style="color:#5bc0de">{{input value=layer.settings.buttonText }}
   {{fa-icon "download"}}</a>
         {{else}}
-            <a class="btn pull-right btn-info btn-outline-cus btn-lg" href={{layer.settings.values.downloadLink}} >{{layer.settings.values.buttonText }}{{fa-icon "download"}}</a>
+            <a class="btn pull-right btn-info btn-outline-cus btn-lg" href={{layer.settings.downloadLink}} >{{layer.settings.buttonText }}{{fa-icon "download"}}</a>
         {{/if}}
     {{/if}}
 </div>

--- a/app/components/layer-image-text/component.js
+++ b/app/components/layer-image-text/component.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-	imageOnLeft: Ember.observer('layer.settings.values.alignment', 'editMode', function() {
-		if(this.get('layer.settings.values.alignment') === 'center'){
+	imageOnLeft: Ember.observer('layer.settings.alignment', 'editMode', function() {
+		if(this.get('layer.settings.alignment') === 'center'){
 			Ember.$('textarea').addClass('side-description')
 		}else{
 			Ember.$('textarea').removeClass('side-description')

--- a/app/components/layer-image-text/template.hbs
+++ b/app/components/layer-image-text/template.hbs
@@ -1,14 +1,14 @@
-{{edit-text showSettings=showSettings editMode=editMode layer=layer type="title" alignment=layer.settings.values.alignment}}
+{{edit-text showSettings=showSettings editMode=editMode layer=layer type="title" alignment=layer.settings.alignment}}
 
 <div style="margin:25px">
 	<div>
-		<img align={{layer.settings.values.alignment}} class="{{layer.settings.values.alignment}} margin-bottom-5" src="{{layer.settings.values.image}}">
+		<img align={{layer.settings.alignment}} class="{{layer.settings.alignment}} margin-bottom-5" src="{{layer.settings.image}}">
 	</div>
 	<div style="margin-bottom:25px;">
     {{#if editMode}}
-        {{textarea class="edit-text" rows="6" cols="50" value=layer.settings.values.sectionDescription}}
+        {{textarea class="edit-text" rows="6" cols="50" value=layer.settings.sectionDescription}}
     {{else}}
-        {{layer.settings.values.sectionDescription}}
+        {{layer.settings.sectionDescription}}
     {{/if}}
 	</div>
 </div>

--- a/app/components/layer-info/template.hbs
+++ b/app/components/layer-info/template.hbs
@@ -1,12 +1,12 @@
 <div>
-    {{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.values.alignment}}
+    {{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.alignment}}
 
-    {{#if layer.settings.values.showDescription}}
+    {{#if layer.settings.showDescription}}
         <h4>Description</h4>
         <p>{{node.description}}</p>
     {{/if}}
 
-    {{#if (and layer.settings.values.showContributors (not layer.settings.values.showBibliographicContributors))}}
+    {{#if (and layer.settings.showContributors (not layer.settings.showBibliographicContributors))}}
         <div class="m-v-md">
             <h4> Contributors </h4>
             {{#each users as |user|}}
@@ -16,7 +16,7 @@
     {{/if}}
 
 
-    {{#if layer.settings.values.showBibliographicContributors}}
+    {{#if layer.settings.showBibliographicContributors}}
         <div class="m-v-md">
             <h4>Bibliographic Contributors</h4>
             {{#each bibliographicUsers as |user|}}
@@ -25,7 +25,7 @@
         </div>
     {{/if}}
 
-    {{#if (and layer.settings.values.showAffiliatedInstitutions institutions)}}
+    {{#if (and layer.settings.showAffiliatedInstitutions institutions)}}
         <div class="m-v-md">
             <h4>Affiliated Institutions</h4>
             {{#each institutions as |institution|}}

--- a/app/components/layer-link/template.hbs
+++ b/app/components/layer-link/template.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 
-{{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.values.alignment}}
+{{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.alignment}}
 <div class="layer-footer p-v-md">
     <div class="container">
         <div class="row">
@@ -12,13 +12,13 @@
             {{edit-text showSettings=showSettings editMode=editMode layer=layer}}
             {{#if editMode}}
                 <p class="text-muted m-b-sm">Link:</p>
-                {{input value=layer.settings.values.sectionLink class="form-control"}}
+                {{input value=layer.settings.sectionLink class="form-control"}}
             {{/if}}
             </div>
             <div class="col-sm-2">
 
-				{{#if layer.settings.values.sectionLink}}
-                    <a href="//{{layer.settings.values.sectionLink}}" type="button" class="btn-outline-cus btn btn-info btn-lg" target="_blank">Open</a>
+				{{#if layer.settings.sectionLink}}
+                    <a href="//{{layer.settings.sectionLink}}" type="button" class="btn-outline-cus btn btn-info btn-lg" target="_blank">Open</a>
                 {{/if}}
 
             </div>

--- a/app/components/layer-settings/component.js
+++ b/app/components/layer-settings/component.js
@@ -3,8 +3,6 @@
 import Ember from 'ember';
 import {layerSettings} from './settings';
 
-console.log(layerSettings);
-
 const helpText = {
     'layer-info': 'The information section is used for displaying your project description, contributors and affiliated institutions from you OSF project.',
     'layer-title': 'The title section is used for displaying the title of your OSF project, all data here is pulled directly from your project.',
@@ -22,6 +20,9 @@ const helpText = {
 export default Ember.Component.extend({
     helpText,
     layerSettings,
+    thisLayerSettings: Ember.computed('layer.component', function(){
+        return this.get('')
+    }),
     file_object: null,
     showRemoveModal: false,
     showUploadModal: false,
@@ -55,8 +56,7 @@ export default Ember.Component.extend({
                     name: files[0].name,
                 });
         },
-        error(one, two, three, four){
-            console.log(one, two, three, four);
+        error(){
         },
         sending(_, dropzone, file, xhr/* formData */) {
             let _send = xhr.send;
@@ -74,14 +74,14 @@ export default Ember.Component.extend({
         },
         changeSize(direction, item){
             if(direction === 'bigger') {
-                this.incrementProperty('layer.settings.values.' + item.get('value'), item.get('incrementSize'));
+                this.incrementProperty('layer.settings.' + item.value, item.incrementSize);
             }
             if(direction === 'smaller') {
-                this.decrementProperty('layer.settings.values.' + item.get('value'), item.get('incrementSize'));
+                this.decrementProperty('layer.settings.' + item.value, item.incrementSize);
             }
         },
         runOption(option, item){
-            this.set('layer.settings.values.' + item.get('value'), option);
+            this.set('layer.settings.' + item.value, option);
         },
         // Move layer
         moveBefore(index){
@@ -112,14 +112,13 @@ export default Ember.Component.extend({
             this.set('showRemoveModal', false);
         },
         toggleCheck(check){
-            this.toggleProperty('layer.settings.values.' + check.get('value'));
+            this.toggleProperty('layer.settings.' + check.value);
         },
         fileDetail(item){
-            console.log('DEBUGGER', item.get('links').download)
-            this.set('layer.settings.values.backgroundImage' , item.get('links').download);
+            this.set('layer.settings.backgroundImage' , item.get('links').download);
         },
         applyUploadedImage(){
-            this.set('layer.settings.values.backgroundImage' , this.get('uploadedImageUrl'));
+            this.set('layer.settings.backgroundImage' , this.get('uploadedImageUrl'));
             this.set('showUploadModal', false);
             this.set('uploadedImageUrl', null);
         },

--- a/app/components/layer-settings/component.js
+++ b/app/components/layer-settings/component.js
@@ -1,6 +1,9 @@
 /*global $:true*/
 
 import Ember from 'ember';
+import {layerSettings} from './settings';
+
+console.log(layerSettings);
 
 const helpText = {
     'layer-info': 'The information section is used for displaying your project description, contributors and affiliated institutions from you OSF project.',
@@ -18,6 +21,7 @@ const helpText = {
 
 export default Ember.Component.extend({
     helpText,
+    layerSettings,
     file_object: null,
     showRemoveModal: false,
     showUploadModal: false,
@@ -97,6 +101,7 @@ export default Ember.Component.extend({
         // Remove layer
         showRemove(){
             this.set('showRemoveModal', true);
+            console.log(this.get('layerSettings'));
         },
         hideRemove(){
             this.set('showRemoveModal', false);

--- a/app/components/layer-settings/settings.js
+++ b/app/components/layer-settings/settings.js
@@ -1,0 +1,270 @@
+{
+    "layer-settings": [
+        {
+            "component": "layer-title",
+            "form": [
+                {
+                    "type": "image",
+                    "label": "Background image",
+                    "value": "backgroundImage",
+                    "validation": null
+                },
+                {
+                    "type": "increment",
+                    "label": "Title size",
+                    "value": "h1Size",
+                    "size": 20,
+                    "incrementSize": 4,
+                    "validation": null
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                },
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show navigation",
+                            "value": "showNavigation",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Fit image to section size",
+                            "value": "backgroundCover",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show title",
+                            "value": "showTitle",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show lead text",
+                            "value": "showLead",
+                            "validation": null
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "component": "layer-info",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show in navigation",
+                            "value": "showInNavigation",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show description",
+                            "value": "showDescription",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show contributors",
+                            "value": "showContributors",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show only bibliographic contributors",
+                            "value": "showBibliographicContributors",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show affiliated institutions",
+                            "value": "showAffiliatedInstitutions",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                }
+            ]
+        },
+        {
+            "component": "layer-link",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show in navigation",
+                            "value": "showInNavigation",
+                            "validation": null
+                        },
+                        {
+                            "type": "text",
+                            "label": "Link address",
+                            "value": "sectionLink",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                }
+            ]
+        },
+        {
+            "component": "layer-image",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+
+                        {
+                            "type": "checkbox",
+                            "label": "Fit image to section size",
+                            "value": "backgroundCover",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "image",
+                    "label": "Background image",
+                    "value": "backgroundImage",
+                    "validation": null
+                },
+                {
+                    "type": "increment",
+                    "label": "Section height",
+                    "value": "height",
+                    "incrementSize": 20,
+                    "validation": null
+                }
+            ]
+        },
+        {
+            "component": "layer-file",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show in navigation",
+                            "value": "showInNavigation",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Show file viewer",
+                            "value": "showFileviewer",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                }
+            ]
+        },
+        {
+            "component": "layer-advanced",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show in navigation",
+                            "value": "showInNavigation",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                }
+            ]
+        },
+        {
+            "component": "layer-wiki",
+            "form": [
+                {
+                    "type": "settings",
+                    "items": [
+                        {
+                            "type": "checkbox",
+                            "label": "Show in navigation",
+                            "value": "showInNavigation",
+                            "validation": null
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Add show more",
+                            "value": "addShowMore",
+                            "validation": null
+                        }
+                    ]
+                },
+                {
+                    "type": "alignment",
+                    "label": "Alignment",
+                    "value": "alignment",
+                    "options": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "validation": null
+                }
+            ]
+        }
+    ]
+}

--- a/app/components/layer-settings/settings.js
+++ b/app/components/layer-settings/settings.js
@@ -1,270 +1,256 @@
-{
-    "layer-settings": [
-        {
-            "component": "layer-title",
-            "form": [
-                {
-                    "type": "image",
-                    "label": "Background image",
-                    "value": "backgroundImage",
-                    "validation": null
-                },
-                {
-                    "type": "increment",
-                    "label": "Title size",
-                    "value": "h1Size",
-                    "size": 20,
-                    "incrementSize": 4,
-                    "validation": null
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                },
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show navigation",
-                            "value": "showNavigation",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Fit image to section size",
-                            "value": "backgroundCover",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show title",
-                            "value": "showTitle",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show lead text",
-                            "value": "showLead",
-                            "validation": null
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "component": "layer-info",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show in navigation",
-                            "value": "showInNavigation",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show description",
-                            "value": "showDescription",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show contributors",
-                            "value": "showContributors",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show only bibliographic contributors",
-                            "value": "showBibliographicContributors",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show affiliated institutions",
-                            "value": "showAffiliatedInstitutions",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                }
-            ]
-        },
-        {
-            "component": "layer-link",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show in navigation",
-                            "value": "showInNavigation",
-                            "validation": null
-                        },
-                        {
-                            "type": "text",
-                            "label": "Link address",
-                            "value": "sectionLink",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                }
-            ]
-        },
-        {
-            "component": "layer-image",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
+/*
+ *   Definition of settings bar components by component type.
+ *   If you define a new component, you may define settings for them here or use default
+ */
 
-                        {
-                            "type": "checkbox",
-                            "label": "Fit image to section size",
-                            "value": "backgroundCover",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "image",
-                    "label": "Background image",
-                    "value": "backgroundImage",
-                    "validation": null
-                },
-                {
-                    "type": "increment",
-                    "label": "Section height",
-                    "value": "height",
-                    "incrementSize": 20,
-                    "validation": null
-                }
-            ]
-        },
-        {
-            "component": "layer-file",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show in navigation",
-                            "value": "showInNavigation",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Show file viewer",
-                            "value": "showFileviewer",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                }
-            ]
-        },
-        {
-            "component": "layer-advanced",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show in navigation",
-                            "value": "showInNavigation",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                }
-            ]
-        },
-        {
-            "component": "layer-wiki",
-            "form": [
-                {
-                    "type": "settings",
-                    "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Show in navigation",
-                            "value": "showInNavigation",
-                            "validation": null
-                        },
-                        {
-                            "type": "checkbox",
-                            "label": "Add show more",
-                            "value": "addShowMore",
-                            "validation": null
-                        }
-                    ]
-                },
-                {
-                    "type": "alignment",
-                    "label": "Alignment",
-                    "value": "alignment",
-                    "options": [
-                        "left",
-                        "center",
-                        "right"
-                    ],
-                    "validation": null
-                }
-            ]
-        }
-    ]
+let layerSettings = {
+        "layer-title": [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show navigation",
+                        "value": "showNavigation",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Fit image to section size",
+                        "value": "backgroundCover",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show title",
+                        "value": "showTitle",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show lead text",
+                        "value": "showLead",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "image",
+                "label": "Background image",
+                "value": "backgroundImage",
+                "validation": null
+            },
+            {
+                "type": "increment",
+                "label": "Title size",
+                "value": "h1Size",
+                "size": 20,
+                "incrementSize": 4,
+                "validation": null
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ],
+        "layer-info": [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show in navigation",
+                        "value": "showInNavigation",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show description",
+                        "value": "showDescription",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show contributors",
+                        "value": "showContributors",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show only bibliographic contributors",
+                        "value": "showBibliographicContributors",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show affiliated institutions",
+                        "value": "showAffiliatedInstitutions",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ],
+        "layer-link" : [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show in navigation",
+                        "value": "showInNavigation",
+                        "validation": null
+                    },
+                    {
+                        "type": "text",
+                        "label": "Link address",
+                        "value": "sectionLink",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ],
+        "layer-image": [
+            {
+                "type": "settings",
+                "items": [
+
+                    {
+                        "type": "checkbox",
+                        "label": "Fit image to section size",
+                        "value": "backgroundCover",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "image",
+                "label": "Background image",
+                "value": "backgroundImage",
+                "validation": null
+            },
+            {
+                "type": "increment",
+                "label": "Section height",
+                "value": "height",
+                "incrementSize": 20,
+                "validation": null
+            }
+        ],
+        "layer-file": [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show in navigation",
+                        "value": "showInNavigation",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Show file viewer",
+                        "value": "showFileviewer",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ],
+        "layer-advanced": [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show in navigation",
+                        "value": "showInNavigation",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ],
+        "layer-wiki": [
+            {
+                "type": "settings",
+                "items": [
+                    {
+                        "type": "checkbox",
+                        "label": "Show in navigation",
+                        "value": "showInNavigation",
+                        "validation": null
+                    },
+                    {
+                        "type": "checkbox",
+                        "label": "Add show more",
+                        "value": "addShowMore",
+                        "validation": null
+                    }
+                ]
+            },
+            {
+                "type": "alignment",
+                "label": "Alignment",
+                "value": "alignment",
+                "options": [
+                    "left",
+                    "center",
+                    "right"
+                ],
+                "validation": null
+            }
+        ]
 }
+
+export {
+    layerSettings
+};

--- a/app/components/layer-settings/template.hbs
+++ b/app/components/layer-settings/template.hbs
@@ -16,79 +16,73 @@
             <div class="settings-button" disabled> <i class="material-icons">arrow_downward</i>  {{#bs-tooltip placement="bottom"}}Already at bottom{{/bs-tooltip}}</div>
             {{/if}}
         </div>
+
         <div class="inline-block settings-divider m-h-sm"></div>
-        {{#each layer.settings.form as |item|}}
-        {{#if (eq item.type 'image')}}
-        <div class="inline-block">
-            <div class="settings-button">
-                <i class="material-icons">insert_photo</i>
+        {{#each (get layerSettings layer.component) as |item|}}
+            {{#if (eq item.type 'image')}}
+                <div class="inline-block">
+                    <div class="settings-button">
+                        <i class="material-icons">insert_photo</i>
 
-                {{#bs-tooltip placement="bottom"}}{{item.label}}{{/bs-tooltip}}
-            </div>
-            {{#bs-popover placement="bottom"}}
-            {{input class="form-control" value=(get layer.settings.values item.value)  type="text"}}
-                <h5>Select Image <span {{action 'showUpload'}} class="pseudo-link">(click here to upload)</span></h5>
-            {{file-browser rootItem=node openFile=(action 'fileDetail')}}
-            {{/bs-popover}}
-        </div>
-
-
-        {{/if}}
-
-
-        {{#if (eq item.type 'increment')}}
-        <div class="inline-block settings-group">
-            {{item.label}}
-            <div class="settings-button text-small" {{action 'changeSize' 'smaller' item}}><i class="material-icons">remove</i> </div>
-            {{layer.settings.values.h1Size}}
-            <div class="settings-button text-big" {{action 'changeSize' 'bigger' item}}><i class="material-icons">add</i> </div>
-        </div>
-        {{/if}}
-
-        {{#if (eq item.type 'alignment')}}
-        <div class="inline-block">
-            <div class="btn-group" role="group" aria-label="...">
-                {{#each item.options as |option|}}
-                <div type="button" class="settings-button {{if (eq layer.settings.values.alignment option) 'active'}}" {{action 'runOption' option item}} >
-                    <i class="material-icons">
-                        {{#if (eq option 'left')}}
-                        format_align_left
-                        {{/if}}
-                        {{#if (eq option 'center')}}
-                        format_align_center
-                        {{/if}}
-                        {{#if (eq option 'right')}}
-                        format_align_right
-                        {{/if}}
-                    </i>
+                        {{#bs-tooltip placement="bottom"}}{{item.label}}{{/bs-tooltip}}
+                    </div>
+                    {{#bs-popover placement="bottom"}}
+                    {{input class="form-control" value=(get layer.settings item.value)  type="text"}}
+                        <h5>Select Image <span {{action 'showUpload'}} class="pseudo-link">(click here to upload)</span></h5>
+                    {{file-browser rootItem=node openFile=(action 'fileDetail')}}
+                    {{/bs-popover}}
                 </div>
-
-                {{/each}}
-            </div>
-        </div>
-        {{/if}}
-
-        {{#if (eq item.type 'settings')}}
-        <div class="settings-block inline-block">
-            <i class="material-icons">settings</i>
-            <i class="material-icons">arrow_drop_down</i>
-            {{#bs-popover placement="bottom"}}
-            {{#each item.items as |check|}}
-            {{#if (eq check.type 'checkbox')}}
-            <div class="checkbox m-v-md" {{action 'toggleCheck' check}}>
-                {{#if (get layer.settings.values check.value)}}
-                <i class="material-icons text-success">check</i>
-                {{else}}
-                <i class="material-icons text-disabled">check</i>
-                {{/if}}
-                {{check.label}}
-            </div>
             {{/if}}
-            {{/each}}
-            {{/bs-popover}}
-        </div>
-        {{/if}}
-        <div class="inline-block settings-divider m-h-sm"></div>
+            {{#if (eq item.type 'increment')}}
+                <div class="inline-block settings-group">
+                    {{item.label}}
+                    <div class="settings-button text-small" {{action 'changeSize' 'smaller' item}}><i class="material-icons">remove</i> </div>
+                    {{layer.settings.h1Size}}
+                    <div class="settings-button text-big" {{action 'changeSize' 'bigger' item}}><i class="material-icons">add</i> </div>
+                </div>
+            {{/if}}
+            {{#if (eq item.type 'alignment')}}
+                <div class="inline-block">
+                    <div class="btn-group" role="group" aria-label="...">
+                        {{#each item.options as |option|}}
+                            <div type="button" class="settings-button {{if (eq layer.settings.alignment option) 'active'}}" {{action 'runOption' option item}} >
+                                <i class="material-icons">
+                                    {{#if (eq option 'left')}}
+                                    format_align_left
+                                    {{/if}}
+                                    {{#if (eq option 'center')}}
+                                    format_align_center
+                                    {{/if}}
+                                    {{#if (eq option 'right')}}
+                                    format_align_right
+                                    {{/if}}
+                                </i>
+                            </div>
+                        {{/each}}
+                    </div>
+                </div>
+            {{/if}}
+            {{#if (eq item.type 'settings')}}
+                <div class="settings-block inline-block">
+                    <i class="material-icons">settings</i>
+                    <i class="material-icons">arrow_drop_down</i>
+                    {{#bs-popover placement="bottom"}}
+                        {{#each item.items as |check|}}
+                            {{#if (eq check.type 'checkbox')}}
+                            <div class="checkbox m-v-md" {{action 'toggleCheck' check}}>
+                                {{#if (get layer.settings check.value)}}
+                                    <i class="material-icons text-success">check</i>
+                                {{else}}
+                                    <i class="material-icons text-disabled">check</i>
+                                {{/if}}
+                                {{check.label}}
+                            </div>
+                            {{/if}}
+                        {{/each}}
+                    {{/bs-popover}}
+                </div>
+            {{/if}}
+            <div class="inline-block settings-divider m-h-sm"></div>
         {{/each}}
 
 
@@ -96,50 +90,51 @@
             <div class="settings-group">
                 <i class="material-icons">format_color_fill</i>
                 {{spectrum-color-picker
-                color=layer.settings.values.bgColor
-                showInput=true
-                preferredFormat='hex'
-                showPalette=true
-                palette=backgroundPalette
-                showPaletteOnly=true
-                togglePaletteOnly=true
-                hideAfterPaletteSelect=true
-                showInitial=true
-                chooseText='Select'
-            }}
+                    color=layer.settings.bgColor
+                    showInput=true
+                    preferredFormat='hex'
+                    showPalette=true
+                    palette=backgroundPalette
+                    showPaletteOnly=true
+                    togglePaletteOnly=true
+                    hideAfterPaletteSelect=true
+                    showInitial=true
+                    chooseText='Select'
+                }}
+            </div>
+
+            <div class="settings-group">
+                <i class="material-icons">format_color_text</i>
+                {{spectrum-color-picker
+                    color=layer.settings.color
+                    showInput=true
+                    preferredFormat='hex'
+                    showPalette=true
+                    palette=colorPalette
+                    showPaletteOnly=true
+                    togglePaletteOnly=true
+                    hideAfterPaletteSelect=true
+                    showInitial=true
+                    chooseText='Select'
+                }}
+            </div>
+
+            <div class="inline-block settings-divider m-h-sm"></div>
+
+            <div class="inline-block settings-button" >
+                <i class="material-icons info-circle ">info_outline</i>
+                {{#bs-popover placement="bottom"}}
+                {{get helpText layer.component}}
+                {{/bs-popover}}
+            </div>
         </div>
-        <div class="settings-group">
-            <i class="material-icons">format_color_text</i> {{spectrum-color-picker
-            color=layer.settings.values.color
-            showInput=true
-            preferredFormat='hex'
-            showPalette=true
-            palette=colorPalette
-            showPaletteOnly=true
-            togglePaletteOnly=true
-            hideAfterPaletteSelect=true
-            showInitial=true
-            chooseText='Select'
 
-        }}
+
+        <div class="inline-block pull-right" {{action 'showRemove'}}>
+            <div class="settings-button remove-layer-toggle"><i class="material-icons">delete</i> </div>
+        </div>
+
     </div>
-
-    <div class="inline-block settings-divider m-h-sm"></div>
-
-    <div class="inline-block settings-button" >
-        <i class="material-icons info-circle ">info_outline</i>
-        {{#bs-popover placement="bottom"}}
-        {{get helpText layer.component}}
-        {{/bs-popover}}
-    </div>
-</div>
-
-
-<div class="inline-block pull-right" {{action 'showRemove'}}>
-    <div class="settings-button remove-layer-toggle"><i class="material-icons">delete</i> </div>
-</div>
-
-</div>
 </div>
 
 

--- a/app/components/layer-title/component.js
+++ b/app/components/layer-title/component.js
@@ -3,15 +3,15 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-	titleStyle: Ember.computed('layer.settings.values.h1Size', function(){
-		let size = this.get('layer.settings.values.h1Size') || 30;
+	titleStyle: Ember.computed('layer.settings.h1Size', function(){
+		let size = this.get('layer.settings.h1Size') || 30;
 		return Ember.String.htmlSafe('font-size: ' + size + 'px;');
 	}),
 	didRender(){
 		let self = this;
 		$.each(this.get('layers.content'), function( index, layer ) {
 			if(layer.component === 'pages-menu'){
-				self.set('layer.settings.values.showNavigation' , false)
+				self.set('layer.settings.showNavigation' , false)
 			}
 		});
 	}

--- a/app/components/layer-title/template.hbs
+++ b/app/components/layer-title/template.hbs
@@ -1,17 +1,17 @@
-<div class="layer-title-content {{layer.settings.values.alignment}}">
-    {{#if layer.settings.values.showTitle}}
+<div class="layer-title-content {{layer.settings.alignment}}">
+    {{#if layer.settings.showTitle}}
         <h1 class="title" style="{{titleStyle}}">{{node.title}}</h1>
     {{/if}}
 
-    {{#if layer.settings.values.showLead}}
+    {{#if layer.settings.showLead}}
         {{#if editMode}}
-            {{input class="edit-title-lead" value=layer.settings.values.lead}}
+            {{input class="edit-title-lead" value=layer.settings.lead}}
         {{else}}
-            <p class="lead">{{layer.settings.values.lead}}</p>
+            <p class="lead">{{layer.settings.lead}}</p>
         {{/if}}
     {{/if}}
 
-    {{#if layer.settings.values.showNavigation}}
+    {{#if layer.settings.showNavigation}}
         <div class="title-menu clearfix m-t-xl">
             {{pages-menu layers=layers theme=theme layer=layer}}
         </div>

--- a/app/components/layer-wiki/template.hbs
+++ b/app/components/layer-wiki/template.hbs
@@ -1,10 +1,10 @@
 <div class="">
-    {{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.values.alignment}}
+    {{edit-text showSettings=showSettings editMode=editMode layer=layer type="title"  alignment=layer.settings.alignment}}
 
-    <div class="wiki-markdown {{if (and isTruncated layer.settings.values.addShowMore) 'truncated'}} ">
+    <div class="wiki-markdown {{if (and isTruncated layer.settings.addShowMore) 'truncated'}} ">
         {{markdown-to-html wikiContent}}
     </div>
-    {{#if layer.settings.values.addShowMore}}
+    {{#if layer.settings.addShowMore}}
         <div class="show-more {{if isTruncated 'truncated'}}" {{action 'toggleShow'}}>
             {{#if isTruncated}}
                 <i class="material-icons ">keyboard_arrow_down</i>

--- a/app/components/layer-wrapper/component.js
+++ b/app/components/layer-wrapper/component.js
@@ -2,16 +2,16 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     showSettings: false,
-    style: Ember.computed('layer.settings.values.bgColor', 'layer.settings.values.color', 'layer.settings.values.url', 'layer.settings.values.backgroundImage', 'layer.settings.values.backgroundCover', 'layer.settings.values.height', function(){
-        let bgColor =  'background-color: ' + (this.get('layer.settings.values.bgColor') || '#FFF') + '; ';
-        let color =  'color: ' + (this.get('layer.settings.values.color') || '#333') + '; ' ;
+    style: Ember.computed('layer.settings.bgColor', 'layer.settings.color', 'layer.settings.url', 'layer.settings.backgroundImage', 'layer.settings.backgroundCover', 'layer.settings.height', function(){
+        let bgColor =  'background-color: ' + (this.get('layer.settings.bgColor') || '#FFF') + '; ';
+        let color =  'color: ' + (this.get('layer.settings.color') || '#333') + '; ' ;
         let bgImage = '';
         let bgCover = '';
-        if (this.get('layer.settings.values.backgroundImage')){
-            bgCover = this.get('layer.settings.values.backgroundCover') ? ' background-size: cover;' : '';
-            bgImage = 'background-image: url(' + this.get('layer.settings.values.backgroundImage') + '); ';
+        if (this.get('layer.settings.backgroundImage')){
+            bgCover = this.get('layer.settings.backgroundCover') ? ' background-size: cover;' : '';
+            bgImage = 'background-image: url(' + this.get('layer.settings.backgroundImage') + '); ';
         }
-        let height = this.get('layer.settings.values.height') ? 'height: ' + this.get('layer.settings.values.height') + 'px;' : '';
+        let height = this.get('layer.settings.height') ? 'height: ' + this.get('layer.settings.height') + 'px;' : '';
         return Ember.String.htmlSafe(bgImage + bgCover + height + bgColor + color);
     }),
     actions: {

--- a/app/components/pages-menu/component.js
+++ b/app/components/pages-menu/component.js
@@ -2,8 +2,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    style: Ember.computed('layer.settings.values.color', 'layer.settings.values.fontSize', function(){
-        return Ember.String.htmlSafe('color: ' + (this.get('layer.settings.values.color') || '#333') + '; font-size: ' +  (this.get('layer.settings.values.fontSize')) + 'px;');
+    style: Ember.computed('layer.settings.color', 'layer.settings.fontSize', function(){
+        return Ember.String.htmlSafe('color: ' + (this.get('layer.settings.color') || '#333') + '; font-size: ' +  (this.get('layer.settings.fontSize')) + 'px;');
     }),
     didRender(){
         let topOfNav = null;
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
             topOfNav = $('.pages-menu').offset().top;
         }
         let self = this;
-        if(this.get('layer.settings.values.stickToTop')){
+        if(this.get('layer.settings.stickToTop')){
             $(window).on('scroll.nav', function () {
                 let paddedNavOffset = null;
                 paddedNavOffset = topOfNav;
@@ -62,7 +62,7 @@ export default Ember.Component.extend({
             if($('.editMenu')[0]){
                 $('.pages-menu').removeClass('sticky-nav-adjustment')
             }
-        }    
+        }
 
         $('.layer-content').css('padding' , '0');
     },

--- a/app/components/pages-menu/template.hbs
+++ b/app/components/pages-menu/template.hbs
@@ -1,9 +1,9 @@
-<div class="pages-nav nav navbar-nav {{layer.settings.values.alignment}}">
+<div class="pages-nav nav navbar-nav {{layer.settings.alignment}}">
     <ul>
         {{#each layers as |layer index|}}
-            {{#if layer.settings.values.showInNavigation}}
+            {{#if layer.settings.showInNavigation}}
                 <li>
-                    <button class="btn btn-link" {{action 'scrollToLayer' index}} style="{{style}}">{{layer.settings.values.sectionTitle}}</button>
+                    <button class="btn btn-link" {{action 'scrollToLayer' index}} style="{{style}}">{{layer.settings.sectionTitle}}</button>
                 </li>
             {{/if}}
         {{/each}}

--- a/public/themes/theme_1.json
+++ b/public/themes/theme_1.json
@@ -6,271 +6,70 @@
             "sectionHeader": "Title",
             "component": "layer-title",
             "settings": {
-                "values": {
-                    "backgroundImage": "http://localhost:4200/img/bg.png",
-                    "backgroundCover": true,
-                    "showNavigation": true,
-                    "showTitle": true,
-                    "showLead": true,
-                    "showInNavigation": false,
-                    "h1Size": 46,
-                    "bgColor": "#333333",
-                    "color": "#EEEEEE",
-                    "alignment": "center",
-                    "lead": "Reproducible study of solar powered lighthouses"
-                },
-                "form": [
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Title size",
-                        "value": "h1Size",
-                        "size": 20,
-                        "incrementSize": 4,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show navigation",
-                                "value": "showNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Fit image to section size",
-                                "value": "backgroundCover",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show title",
-                                "value": "showTitle",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show lead text",
-                                "value": "showLead",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "backgroundImage": "http://localhost:4200/img/bg.png",
+                "backgroundCover": true,
+                "showNavigation": true,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 46,
+                "bgColor": "#333333",
+                "color": "#EEEEEE",
+                "alignment": "center",
+                "lead": "Reproducible study of solar powered lighthouses"
             }
         },
         {
             "sectionHeader": "Info",
             "component": "layer-info",
             "settings": {
-                "values": {
-                    "sectionTitle": "About this project",
-                    "showInNavigation": true,
-                    "showDescription": true,
-                    "showContributors": true,
-                    "showBibliographicContributors": false,
-                    "showAffiliatedInstitutions": true,
-                    "bgColor": "#eeeeee",
-                    "alignment": "left",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show description",
-                                "value": "showDescription",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show contributors",
-                                "value": "showContributors",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show only bibliographic contributors",
-                                "value": "showBibliographicContributors",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show affiliated institutions",
-                                "value": "showAffiliatedInstitutions",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "About this project",
+                "showInNavigation": true,
+                "showDescription": true,
+                "showContributors": true,
+                "showBibliographicContributors": false,
+                "showAffiliatedInstitutions": true,
+                "bgColor": "#eeeeee",
+                "alignment": "left",
+                "color": "#333333"
             }
         },
         {
             "sectionHeader": "Link",
             "component": "layer-link",
             "settings": {
-                "values": {
-                    "sectionTitle": "Fresnel lens information",
-                    "showInNavigation": true,
-                    "sectionDescription": "Fresnel lens is a type of compact lens originally developed by French physicist Augustin-Jean Fresnel for lighthouses. Learn more about it in Wikipedia",
-                    "sectionLink": "https://en.wikipedia.org/wiki/Fresnel_lens",
-                    "bgColor": "#00bcd4",
-                    "alignment": "left",
-                    "color": "#ffffff"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "text",
-                                "label": "Link address",
-                                "value": "sectionLink",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Fresnel lens information",
+                "showInNavigation": true,
+                "sectionDescription": "Fresnel lens is a type of compact lens originally developed by French physicist Augustin-Jean Fresnel for lighthouses. Learn more about it in Wikipedia",
+                "sectionLink": "https://en.wikipedia.org/wiki/Fresnel_lens",
+                "bgColor": "#00bcd4",
+                "alignment": "left",
+                "color": "#ffffff"
             }
         },
         {
             "sectionHeader": "Image",
             "component": "layer-image",
             "settings": {
-                "values": {
-                    "height": 500,
-                    "backgroundImage": "http://localhost:4200/img/sample2.jpg",
-                    "backgroundCover": true,
-                    "bgColor": "#FFFFFF",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                
-                        {
-                            "type": "checkbox",
-                            "label": "Fit image to section size",
-                            "value": "backgroundCover",
-                            "validation": null
-                        }
-                        ]
-                    },
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Section height",
-                        "value": "height",
-                        "incrementSize": 20,
-                        "validation": null
-                    }
-                ]
+                "height": 500,
+                "backgroundImage": "http://localhost:4200/img/sample2.jpg",
+                "backgroundCover": true,
+                "bgColor": "#FFFFFF",
+                "color": "#333333"
             }
         },
         {
             "sectionHeader": "Download",
             "component": "layer-file",
             "settings": {
-                "values": {
-                    "sectionTitle": "Lighthouse report",
-                    "sectionDescription": "",
-                    "showFileviewer": true,
-                    "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/596e6d4b8ca57e022b697cda",
-                    "showInNavigation": true,
-                    "bgColor": "#FFFFFF",
-                    "alignment": "left",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show file viewer",
-                                "value": "showFileviewer",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Lighthouse report",
+                "sectionDescription": "",
+                "showFileviewer": true,
+                "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/596e6d4b8ca57e022b697cda",
+                "showInNavigation": true,
+                "bgColor": "#FFFFFF",
+                "alignment": "left",
+                "color": "#333333"
             }
         },
         {
@@ -278,37 +77,11 @@
             "component": "layer-advanced",
             "content": "<p>Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio.<em> Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. </em>Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at <u>nulla</u>.&nbsp;</p><p><br></p><h3>Suspendisse potenti</h3><p><br></p><p>Sed vitae mi elit. Vestibulum cursus metus dictum accumsan malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. <strong>Proin id pellentesque velit.</strong> Duis sapien tortor, vehicula sit amet odio mattis, fermentum viverra ex. Sed feugiat tristique pellentesque. Duis eget dui ultrices arcu rutrum sagittis. Nam efficitur, urna sit amet faucibus fermentum, justo augue rhoncus metus, in faucibus velit dui a nibh. Nam id urna sed lorem bibendum molestie vel sed ligula. Donec dapibus feugiat leo, vitae rutrum libero commodo ut. Cras imperdiet nibh leo, at cursus eros ultrices quis. Maecenas at rutrum lacus. Etiam non finibus libero. Donec tempus tincidunt feugiat.</p><h3><br></h3><h3>Nullam id viverra ligula</h3><p><br></p><p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nunc mattis metus sed volutpat molestie. Fusce neque odio, blandit id felis ac, fringilla sollicitudin tortor. Pellentesque fermentum quam id lectus pellentesque tempus. Ut vitae nibh ac ligula blandit efficitur. Quisque at ex non lectus mollis tempus. <u>Cras commodo</u> est nec efficitur rutrum.</p><p><br></p><ul><li>Duis sollicitudin tellus vel justo vehicula luctus.</li><li>Quisque velit odio, auctor vitae imperdiet at, tempus ac augue.</li><li>Proin quam leo, egestas sed ligula in, tristique tincidunt nunc. Mauris sodales sem a ex aliquam facilisis.</li><li>Proin volutpat feugiat mi, at volutpat mi rutrum at.</li></ul><p><br></p><p><br></p><h3>Vestibulum at tempor diam</h3><p><br></p><p>Cras non convallis sem, ut convallis elit. Maecenas aliquam neque viverra lacus euismod, eu faucibus neque blandit. Morbi porttitor quam convallis, lacinia justo nec, ultrices felis.</p><p><br></p><p><br></p><blockquote>Nulla euismod a nunc ac fringilla. Donec ut iaculis ante, sit amet consectetur nunc. Aliquam a cursus nulla, eu rhoncus felis. In et orci vel quam consequat scelerisque. Phasellus bibendum augue non interdum aliquam. Nunc id nulla a sapien porttitor hendrerit. Sed aliquam vitae metus a bibendum. Duis aliquet rutrum mattis. Ut a cursus elit. Sed eu nibh eu dui efficitur malesuada.</blockquote><p><br></p><p>Vivamus sem eros, dapibus in elit vel, posuere rhoncus tellus. Cras eleifend finibus nunc vitae consectetur. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc condimentum ante et nisi fringilla, ac pharetra lectus dignissim. Quisque facilisis ullamcorper justo, nec tincidunt ipsum vehicula sed. Aliquam ullamcorper dictum volutpat. Praesent efficitur accumsan tempus. Phasellus at velit ac erat vestibulum auctor et ut tellus. Integer vitae dignissim arcu. Cras eget laoreet urna. Fusce vitae lorem congue quam iaculis lobortis.</p><p><br></p><p><br></p>",
             "settings": {
-                "values": {
-                    "sectionTitle": "Lighthouse characteristics",
-                    "showInNavigation": true,
-                    "bgColor": "#31708f",
-                    "alignment": "left",
-                    "color": "#ffffff"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Lighthouse characteristics",
+                "showInNavigation": true,
+                "bgColor": "#31708f",
+                "alignment": "left",
+                "color": "#ffffff"
             }
         },
         {
@@ -316,44 +89,12 @@
             "component": "layer-wiki",
             "settings": {
                 "wikiId": "",
-                "values": {
-                    "sectionTitle": "Wiki example",
-                    "showInNavigation": true,
-                    "addShowMore": false,
-                    "bgColor": "#FFFFFF",
-                    "alignment": "left",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Add show more",
-                                "value": "addShowMore",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Wiki example",
+                "showInNavigation": true,
+                "addShowMore": false,
+                "bgColor": "#FFFFFF",
+                "alignment": "left",
+                "color": "#333333"
             }
         }
     ]

--- a/public/themes/theme_2.json
+++ b/public/themes/theme_2.json
@@ -6,140 +6,32 @@
             "sectionHeader": "Title",
             "component": "layer-title",
             "settings": {
-                "values": {
-                    "backgroundImage": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995a8360dc3100263180c6a",
-                    "backgroundCover": true,
-                    "showNavigation": true,
-                    "showTitle": true,
-                    "showLead": true,
-                    "showInNavigation": false,
-                    "h1Size": 39,
-                    "bgColor": "#666666",
-                    "color": "#333333",
-                    "alignment": "left",
-                    "lead": "Our research methodology and structure"
-                },
-                "form": [
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Title size",
-                        "value": "h1Size",
-                        "size": 20,
-                        "incrementSize": 4,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show navigation",
-                                "value": "showNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Fit image to section size",
-                                "value": "backgroundCover",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show title",
-                                "value": "showTitle",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show lead text",
-                                "value": "showLead",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "backgroundImage": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995a8360dc3100263180c6a",
+                "backgroundCover": true,
+                "showNavigation": true,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 39,
+                "bgColor": "#666666",
+                "color": "#333333",
+                "alignment": "left",
+                "lead": "Our research methodology and structure"
             }
         },
         {
             "sectionHeader": "Info",
             "component": "layer-info",
             "settings": {
-                "values": {
-                    "sectionTitle": "Project Summary",
-                    "showInNavigation": true,
-                    "showDescription": true,
-                    "showContributors": true,
-                    "showBibliographicContributors": false,
-                    "showAffiliatedInstitutions": true,
-                    "bgColor": "#009688",
-                    "alignment": "center",
-                    "color": "#ffffff"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show description",
-                                "value": "showDescription",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show contributors",
-                                "value": "showContributors",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show only bibliographic contributors",
-                                "value": "showBibliographicContributors",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show affiliated institutions",
-                                "value": "showAffiliatedInstitutions",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Project Summary",
+                "showInNavigation": true,
+                "showDescription": true,
+                "showContributors": true,
+                "showBibliographicContributors": false,
+                "showAffiliatedInstitutions": true,
+                "bgColor": "#009688",
+                "alignment": "center",
+                "color": "#ffffff"
             }
         },
         {
@@ -147,90 +39,25 @@
             "component": "layer-wiki",
             "settings": {
                 "wikiId": "",
-                "values": {
-                    "sectionTitle": "Research questions",
-                    "showInNavigation": true,
-                    "addShowMore": false,
-                    "bgColor": "#FFFFFF",
-                    "alignment": "center",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Add show more",
-                                "value": "addShowMore",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Research questions",
+                "showInNavigation": true,
+                "addShowMore": false,
+                "bgColor": "#FFFFFF",
+                "alignment": "center",
+                "color": "#333333"
             }
         },
         {
             "sectionHeader": "Wiki example",
             "component": "layer-wiki",
             "settings": {
-                "component": "layer-settings",
                 "wikiId": "ukfwn",
-                "values": {
-                    "sectionTitle": "Methodology",
-                    "showInNavigation": true,
-                    "addShowMore": false,
-                    "bgColor": "#414141",
-                    "color": "#ffffff",
-                    "alignment": "center"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Add show more",
-                                "value": "addShowMore",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Methodology",
+                "showInNavigation": true,
+                "addShowMore": false,
+                "bgColor": "#414141",
+                "color": "#ffffff",
+                "alignment": "center"
             }
         },
         {
@@ -238,38 +65,11 @@
             "component": "layer-advanced",
             "content": "<p class=\"ql-align-center\">For questions or inquiries about this research project please get in touch.&nbsp;</p><p class=\"ql-align-center\"><br></p><p class=\"ql-align-center\"><strong>Marcia Gonzales</strong></p><p class=\"ql-align-center\">Principal Investigator, University of Virginia</p><p class=\"ql-align-center\">mcjs456gh@virginia.edu</p>",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Contact Us",
-                    "showInNavigation": true,
-                    "bgColor": "#31708f",
-                    "alignment": "center",
-                    "color": "#f5f5f5"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Contact Us",
+                "showInNavigation": true,
+                "bgColor": "#31708f",
+                "alignment": "center",
+                "color": "#f5f5f5"
             }
         }
     ]

--- a/public/themes/theme_3.json
+++ b/public/themes/theme_3.json
@@ -6,121 +6,31 @@
             "sectionHeader": "Title",
             "component": "layer-title",
             "settings": {
-                "values": {
-                    "backgroundImage": "http://demo.rockettheme.com/live/wordpress/crystalline/wp-content/themes/rt_crystalline_wp/images/overlays/headers/header-1.png",
-                    "backgroundCover": true,
-                    "showNavigation": false,
-                    "showTitle": true,
-                    "showLead": true,
-                    "showInNavigation": false,
-                    "h1Size": 38,
-                    "bgColor": "#eeeeee",
-                    "color": "#333333",
-                    "alignment": "center",
-                    "lead": "Sed vehicula nec ante non porttitor. Cras at eros vel tellus sagittis pharetra rhoncus a ante. "
-                },
-                "form": [
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Title size",
-                        "value": "h1Size",
-                        "size": 20,
-                        "incrementSize": 4,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show navigation",
-                                "value": "showNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Fit image to section size",
-                                "value": "backgroundCover",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show title",
-                                "value": "showTitle",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show lead text",
-                                "value": "showLead",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "backgroundImage": "http://demo.rockettheme.com/live/wordpress/crystalline/wp-content/themes/rt_crystalline_wp/images/overlays/headers/header-1.png",
+                "backgroundCover": true,
+                "showNavigation": false,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 38,
+                "bgColor": "#eeeeee",
+                "color": "#333333",
+                "alignment": "center",
+                "lead": "Sed vehicula nec ante non porttitor. Cras at eros vel tellus sagittis pharetra rhoncus a ante. "
             }
         },
         {
             "sectionHeader": "Download",
             "component": "layer-file",
             "settings": {
-                "values": {
-                    "sectionTitle": "",
-                    "sectionDescription": "<p><br></p>",
-                    "showFileviewer": true,
-                    "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/596e6d4b8ca57e022b697cda",
-                    "showInNavigation": true,
-                    "bgColor": "#eeeeee",
-                    "color": "#333333",
-                    "alignment": "center"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show file viewer",
-                                "value": "showFileviewer",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "",
+                "sectionDescription": "<p><br></p>",
+                "showFileviewer": true,
+                "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/596e6d4b8ca57e022b697cda",
+                "showInNavigation": true,
+                "bgColor": "#eeeeee",
+                "color": "#333333",
+                "alignment": "center"
             }
         }
     ]

--- a/public/themes/theme_4.json
+++ b/public/themes/theme_4.json
@@ -1,235 +1,74 @@
 {
    "id": 4,
    "name": "Institution",
-   "layers":[
+    "layers":[
         {
-          "sectionHeader": "Title",
-          "component": "layer-title",
-          "settings": {
-            "values": {
-              "backgroundImage": "http://localhost:4200/img/logo.png",
-              "backgroundCover": true,
-              "showNavigation": true,
-              "showTitle": true,
-              "showLead": true,
-              "showInNavigation": false,
-              "h1Size": 42,
-              "bgColor": "#ffffff",
-              "color": "#ffffff",
-              "alignment": "right",
-              "lead": "Institution Subtitle"
-            },
-            "form": [
-              {
-                "type": "image",
-                "label": "Background image",
-                "value": "backgroundImage",
-                "validation": null
-              },
-              {
-                "type": "increment",
-                "label": "Title size",
-                "value": "h1Size",
-                "size": 20,
-                "incrementSize": 4,
-                "validation": null
-              },
-              {
-                "type": "alignment",
-                "label": "Alignment",
-                "value": "alignment",
-                "options": [
-                  "left",
-                  "center",
-                  "right"
-                ],
-                "validation": null
-              },
-              {
-                "type": "settings",
-                "items": [
-                  {
-                    "type": "checkbox",
-                    "label": "Show navigation",
-                    "value": "showNavigation",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Fit image to section size",
-                    "value": "backgroundCover",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show title",
-                    "value": "showTitle",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show lead text",
-                    "value": "showLead",
-                    "validation": null
-                  }
-                ]
-              }
-            ]
-          }
+            "sectionHeader": "Title",
+            "component": "layer-title",
+            "settings": {
+                "backgroundImage": "http://localhost:4200/img/logo.png",
+                "backgroundCover": true,
+                "showNavigation": true,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 42,
+                "bgColor": "#ffffff",
+                "color": "#ffffff",
+                "alignment": "right",
+                "lead": "Institution Subtitle"
+            }
         },
         {
-          "sectionHeader": "Advanced",
-          "component": "layer-advanced",
-          "content": "<p>\t\tMauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla.</p><p><br></p><p>\t\tMauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla</p>",
-          "settings": {
-            "values": {
-              "sectionTitle": "About the Institution",
-              "showInNavigation": true,
-              "bgColor": "#f07057",
-              "alignment": "center",
-              "color": "#ffffff"
-            },
-            "form": [
-              {
-                "type": "settings",
-                "items": [
-                  {
-                    "type": "checkbox",
-                    "label": "Show in navigation",
-                    "value": "showInNavigation",
-                    "validation": null
-                  }
-                ]
-              }
-            ]
-          }
+            "sectionHeader": "Advanced",
+            "component": "layer-advanced",
+            "content": "<p>\t\tMauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla.</p><p><br></p><p>\t\tMauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla. Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla</p>",
+            "settings": {
+                "sectionTitle": "About the Institution",
+                "showInNavigation": true,
+                "bgColor": "#f07057",
+                "alignment": "center",
+                "color": "#ffffff"
+            }
         },
         {
             "sectionHeader": "Image",
             "component": "layer-image",
             "settings": {
-                "values": {
-                    "height": 500,
-                    "backgroundImage": "http://localhost:4200/img/building.jpg",
-                    "backgroundCover": true,
-                    "bgColor": "#FFFFFF",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                        {
-                            "type": "checkbox",
-                            "label": "Fit image to section size",
-                            "value": "backgroundCover",
-                            "validation": null
-                        }
-                        ]
-                    },
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Section height",
-                        "value": "height",
-                        "incrementSize": 20,
-                        "validation": null
-                    }
-                ]
+                "height": 500,
+                "backgroundImage": "http://localhost:4200/img/building.jpg",
+                "backgroundCover": true,
+                "bgColor": "#FFFFFF",
+                "color": "#333333"
             }
         },
         {
-          "sectionHeader": "Info",
-          "component": "layer-info",
-          "settings": {
-            "values": {
-              "sectionTitle": "About Institution's Project",
-              "showInNavigation": true,
-              "showDescription": true,
-              "showContributors": true,
-              "showBibliographicContributors": false,
-              "showAffiliatedInstitutions": true,
-              "bgColor": "#FFFFFF",
-              "alignment": "center",
-              "color": "#333333"
-            },
-            "form": [
-              {
-                "type": "settings",
-                "items": [
-                  {
-                    "type": "checkbox",
-                    "label": "Show in navigation",
-                    "value": "showInNavigation",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show description",
-                    "value": "showDescription",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show contributors",
-                    "value": "showContributors",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show only bibliographic contributors",
-                    "value": "showBibliographicContributors",
-                    "validation": null
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Show affiliated institutions",
-                    "value": "showAffiliatedInstitutions",
-                    "validation": null
-                  }
-                ]
-              }
-            ]
-          }
+            "sectionHeader": "Info",
+            "component": "layer-info",
+            "settings": {
+                "sectionTitle": "About Institution's Project",
+                "showInNavigation": true,
+                "showDescription": true,
+                "showContributors": true,
+                "showBibliographicContributors": false,
+                "showAffiliatedInstitutions": true,
+                "bgColor": "#FFFFFF",
+                "alignment": "center",
+                "color": "#333333"
+            }
         },
         {
-          "sectionHeader": "Link",
-          "component": "layer-link",
-          "settings": {
-            "values": {
-              "sectionTitle": "Link to Institution Home Page",
-              "showInNavigation": true,
-              "sectionDescription": "<p>Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla</p>",
-              "sectionLink": "www.example.com",
-              "bgColor": "#31708f",
-              "alignment": "center",
-              "color": "#ffffff"
-            },
-            "form": [
-              {
-                "type": "settings",
-                "items": [
-                  {
-                    "type": "checkbox",
-                    "label": "Show in navigation",
-                    "value": "showInNavigation",
-                    "validation": null
-                  },
-                  {
-                    "type": "text",
-                    "label": "Link address",
-                    "value": "sectionLink",
-                    "validation": null
-                  }
-                ]
-              }
-            ]
-          }
+            "sectionHeader": "Link",
+            "component": "layer-link",
+            "settings": {
+                "sectionTitle": "Link to Institution Home Page",
+                "showInNavigation": true,
+                "sectionDescription": "<p>Mauris imperdie Praesent ut fringilla orci. Proin feugiat auctor augue non rutrum. Sed ac metus in augue dignissim malesuada non et sem. Pellentesque ut metus odio. Integer fringilla nulla id leo consequat, a sollicitudin sapien fringilla. Fusce vestibulum malesuada nisl. Fusce augue leo, tempus eget matssstis vel, imperdiet at nulla</p>",
+                "sectionLink": "www.example.com",
+                "bgColor": "#31708f",
+                "alignment": "center",
+                "color": "#ffffff"
+            }
         }
-      ]
-   }
+    ]
+}

--- a/public/themes/theme_5.json
+++ b/public/themes/theme_5.json
@@ -6,75 +6,17 @@
             "sectionHeader": "Title",
             "component": "layer-title",
             "settings": {
-                "values": {
-                    "backgroundImage": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995b25f0dc310026218020a",
-                    "backgroundCover": true,
-                    "showNavigation": true,
-                    "showTitle": true,
-                    "showLead": true,
-                    "showInNavigation": false,
-                    "h1Size": 34,
-                    "bgColor": "#333333",
-                    "color": "#EEEEEE",
-                    "alignment": "left",
-                    "lead": "Portfolio for Carrina Lee, University of Wisconsin"
-                },
-                "form": [
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Title size",
-                        "value": "h1Size",
-                        "size": 20,
-                        "incrementSize": 4,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show navigation",
-                                "value": "showNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Fit image to section size",
-                                "value": "backgroundCover",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show title",
-                                "value": "showTitle",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show lead text",
-                                "value": "showLead",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "backgroundImage": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995b25f0dc310026218020a",
+                "backgroundCover": true,
+                "showNavigation": true,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 34,
+                "bgColor": "#333333",
+                "color": "#EEEEEE",
+                "alignment": "left",
+                "lead": "Portfolio for Carrina Lee, University of Wisconsin"
             }
         },
         {
@@ -82,38 +24,11 @@
             "component": "layer-advanced",
             "content": "<h3 class=\"ql-align-center\"><br></h3><h3 class=\"ql-align-center\"><span style=\"color: rgb(255, 194, 102);\">Interdisciplinary Perspectives</span></h3><p class=\"ql-align-center\"><br></p><p class=\"ql-align-center\">July 22, 2011</p><p class=\"ql-align-center\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p><p class=\"ql-align-center\">Aeneancommodo ligula eget dolor. Aenean massa. Cum sociis natoque</p><p class=\"ql-align-center\">penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p><p class=\"ql-align-center\">Donec quam felis.</p><p class=\"ql-align-center ql-direction-rtl\"><br></p><p class=\"ql-align-center ql-direction-rtl\"><br></p><h3 class=\"ql-align-center ql-direction-rtl\"><span style=\"color: rgb(102, 163, 224);\">A Spatial History of Poststructuralism</span></h3><p class=\"ql-align-center ql-direction-rtl\">July 11, 2015</p><p class=\"ql-align-center ql-direction-rtl\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean</p><p class=\"ql-align-center ql-direction-rtl\">commodo ligula eget dolor. Aenean massa. Cum sociis natoque</p><p class=\"ql-align-center ql-direction-rtl\">penatibus et magnis dis parturient montes, nascetur ridiculus mu</p><p class=\"ql-align-center ql-direction-rtl\">Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem</p><p class=\"ql-align-center ql-direction-rtl\">Nulla consequat massa quis enim. Donec pede justo</p><p class=\"ql-align-center\"><br></p><h3 class=\"ql-align-center\"><span style=\"color: rgb(255, 194, 102);\">Quantitative Trends in Violence</span></h3><p class=\"ql-align-center\">December 13, 2016</p><p class=\"ql-align-center\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean</p><p class=\"ql-align-center\">commodo ligula eget dolor. Aenean massa. Cum sociis natoque</p><p class=\"ql-align-center\">penatibus et magnis dis parturient montes</p><p><br></p>",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Research ",
-                    "showInNavigation": true,
-                    "bgColor": "#ffffff",
-                    "alignment": "center",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Research ",
+                "showInNavigation": true,
+                "bgColor": "#ffffff",
+                "alignment": "center",
+                "color": "#333333"
             }
         },
         {
@@ -121,85 +36,25 @@
             "component": "layer-advanced",
             "content": "<p class=\"ql-align-center\">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.</p><p class=\"ql-align-center\"><br></p><p class=\"ql-align-center\">Com sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis,</p><p class=\"ql-align-center\">ultricies nec, pellentesque eu, pretium quis, sem.Nulla consequat massa quis enim. Donec pede justo, fringilla vel,</p><p class=\"ql-align-center\">aliquet nec, vulputate eget, arcu.</p><p class=\"ql-align-center\"><br></p><p class=\"ql-align-center\">In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt.</p><p class=\"ql-align-center\">Cras dapibus. Vivamus elementum semper nisi. Aenean</p><p><br></p>",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Bio",
-                    "showInNavigation": true,
-                    "bgColor": "#00bcd4",
-                    "alignment": "center",
-                    "color": "#f5f5f5"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Bio",
+                "showInNavigation": true,
+                "bgColor": "#00bcd4",
+                "alignment": "center",
+                "color": "#f5f5f5"
             }
         },
         {
             "sectionHeader": "Download",
             "component": "layer-file",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Resume",
-                    "sectionDescription": "",
-                    "showFileviewer": true,
-                    "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995b2f78ca57e025a1ee3a7",
-                    "showInNavigation": true,
-                    "bgColor": "#eeeeee",
-                    "alignment": "center",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show file viewer",
-                                "value": "showFileviewer",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Resume",
+                "sectionDescription": "",
+                "showFileviewer": true,
+                "downloadLink": "https://staging-files.osf.io/v1/resources/jyu4t/providers/osfstorage/5995b2f78ca57e025a1ee3a7",
+                "showInNavigation": true,
+                "bgColor": "#eeeeee",
+                "alignment": "center",
+                "color": "#333333"
             }
         },
         {
@@ -207,38 +62,11 @@
             "component": "layer-advanced",
             "content": "<p class=\"ql-align-center\">Please get in touch with general questions or comments here</p><h3 class=\"ql-align-center\">cl23blg@wisconsin.edu</h3><p class=\"ql-align-center\"><br></p><p class=\"ql-align-center\">I'm available for speaking engagements and workshops during summer months.&nbsp;</p><p class=\"ql-align-center\"><br></p>",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Contact",
-                    "showInNavigation": true,
-                    "bgColor": "#31708f",
-                    "alignment": "center",
-                    "color": "#f5f5f5"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Contact",
+                "showInNavigation": true,
+                "bgColor": "#31708f",
+                "alignment": "center",
+                "color": "#f5f5f5"
             }
         }
     ]

--- a/public/themes/theme_6.json
+++ b/public/themes/theme_6.json
@@ -6,212 +6,54 @@
             "sectionHeader": "Title",
             "component": "layer-title",
             "settings": {
-                "values": {
-                    "backgroundImage": "http://localhost:4200/img/rpp.jpg",
-                    "backgroundCover": true,
-                    "showNavigation": false,
-                    "showTitle": true,
-                    "showLead": true,
-                    "showInNavigation": false,
-                    "h1Size": 40,
-                    "bgColor": "#FFFFFF",
-                    "color": "#333333",
-                    "alignment": "right",
-                    "lead": "Open Science Collaboration"
-                },
-                "form": [
-                    {
-                        "type": "image",
-                        "label": "Background image",
-                        "value": "backgroundImage",
-                        "validation": null
-                    },
-                    {
-                        "type": "increment",
-                        "label": "Title size",
-                        "value": "h1Size",
-                        "size": 20,
-                        "incrementSize": 4,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show navigation",
-                                "value": "showNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Fit image to section size",
-                                "value": "backgroundCover",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show title",
-                                "value": "showTitle",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show lead text",
-                                "value": "showLead",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "backgroundImage": "http://localhost:4200/img/rpp.jpg",
+                "backgroundCover": true,
+                "showNavigation": false,
+                "showTitle": true,
+                "showLead": true,
+                "showInNavigation": false,
+                "h1Size": 40,
+                "bgColor": "#FFFFFF",
+                "color": "#333333",
+                "alignment": "right",
+                "lead": "Open Science Collaboration"
             }
         },
         {
             "sectionHeader": "Navigation",
             "component": "pages-menu",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "fontSize": 16,
-                    "bgColor": "#00bcd4",
-                    "color": "#ffffff",
-                    "alignment": "center",
-                    "stickToTop": false
-                },
-                "form": [
-                    {
-                        "type": "increment",
-                        "label": "Font size",
-                        "value": "fontSize",
-                        "incrementSize": 1,
-                        "validation": null
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    },
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Stick to top of page on scroll",
-                                "value": "stickToTop",
-                                "validation": null
-                            }
-                        ]
-                    }
-                ]
+                "fontSize": 16,
+                "bgColor": "#00bcd4",
+                "color": "#ffffff",
+                "alignment": "center",
+                "stickToTop": false
             }
         },
         {
             "sectionHeader": "Wiki example",
             "component": "layer-wiki",
             "settings": {
-                "component": "layer-settings",
                 "wikiId": "",
-                "values": {
-                    "sectionTitle": "About",
-                    "showInNavigation": true,
-                    "addShowMore": false,
-                    "bgColor": "#eeeeee",
-                    "alignment": "left",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Add show more",
-                                "value": "addShowMore",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "About",
+                "showInNavigation": true,
+                "addShowMore": false,
+                "bgColor": "#eeeeee",
+                "alignment": "left",
+                "color": "#333333"
             }
         },
         {
             "sectionHeader": "Wiki example",
             "component": "layer-wiki",
             "settings": {
-                "component": "layer-settings",
                 "wikiId": "yje3h",
-                "values": {
-                    "sectionTitle": "Abstract",
-                    "showInNavigation": true,
-                    "addShowMore": false,
-                    "bgColor": "#009688",
-                    "alignment": "left",
-                    "color": "#ffffff"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Add show more",
-                                "value": "addShowMore",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Abstract",
+                "showInNavigation": true,
+                "addShowMore": false,
+                "bgColor": "#009688",
+                "alignment": "left",
+                "color": "#ffffff"
             },
             "wikiContent": "The Reproducibility Project: Psychology began in November 2011, finished primary data collection in December 2014, and published a summary of the results in August 2015. The project was coordinated by the Center for Open Science. Replication teams followed a research protocol and received logistical assistance as they collected materials, identified the key finding for replication, ran their experiment, conducted analyses, and reported their findings.\r\n\r\nAs stated in an initial report from 2012, \"The Reproducibility Project uses an open methodology to test the reproducibility of psychological science. It also models procedures designed to simplify and improve reproducibility\" (Open Science Collaboration, 2012). To that end, all project materials, data, and findings are posted on the Open Science Framework, a free service of the Center for Open Science. Moreover, the project models reproducibility by making it easy to reproduce the analyses of each individual project, and the results of the aggregate report.\r\n\r\nAs the first in-depth exploration of its kind, the project results provide insight into reproducibility and its correlates. With a large, open dataset, many additional research questions can be investigated.\r\n\r\nThe project was designed to be a collaborative endeavor. Ultimately over 270 contributors earned authorship on the summary report and 86 others provided volunteer support. Replication teams designed, ran, and reported their replication studies. Brian Nosek, Johanna Cohoon, and Mallory Kidwell provided project coordination. Marcel van Assen, Chris Hartgerink, and Robbie van Aert led the analysis of results, Fred Hasselman generated the figures, and Sacha Epskamp led the analysis audit. Scores of additional volunteers assisted with coding of articles, analyses, and administrative tasks.\r\n\r\nSince its inception, other similar initiatives have begun in other scientific domains. The Center for Open Science coordinates one of these such efforts, the Reproducibility Project: Cancer Biology."
         },
@@ -219,140 +61,41 @@
             "sectionHeader": "Download",
             "component": "layer-file",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Download paper",
-                    "sectionDescription": "<p>Download the preprint version of our study from OSF</p>",
-                    "showFileviewer": false,
-                    "downloadLink": "https://staging-files.osf.io/v1/resources/nc43h/providers/osfstorage/59820ae08ca57e02367f2771",
-                    "showInNavigation": true,
-                    "bgColor": "#232323",
-                    "alignment": "left",
-                    "color": "#f5f5f5"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show file viewer",
-                                "value": "showFileviewer",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Download paper",
+                "sectionDescription": "<p>Download the preprint version of our study from OSF</p>",
+                "showFileviewer": false,
+                "downloadLink": "https://staging-files.osf.io/v1/resources/nc43h/providers/osfstorage/59820ae08ca57e02367f2771",
+                "showInNavigation": true,
+                "bgColor": "#232323",
+                "alignment": "left",
+                "color": "#f5f5f5"
             }
         },
         {
             "sectionHeader": "Download",
             "component": "layer-file",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Effect size chart",
-                    "sectionDescription": "<p>Original study effect size versus replication effect size (correlation coefficients).</p>",
-                    "showFileviewer": true,
-                    "downloadLink": "https://staging-files.osf.io/v1/resources/nc43h/providers/osfstorage/59820aa20dc310022eaf02ba",
-                    "showInNavigation": true,
-                    "bgColor": "#FFFFFF",
-                    "alignment": "left",
-                    "color": "#333333"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "checkbox",
-                                "label": "Show file viewer",
-                                "value": "showFileviewer",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Effect size chart",
+                "sectionDescription": "<p>Original study effect size versus replication effect size (correlation coefficients).</p>",
+                "showFileviewer": true,
+                "downloadLink": "https://staging-files.osf.io/v1/resources/nc43h/providers/osfstorage/59820aa20dc310022eaf02ba",
+                "showInNavigation": true,
+                "bgColor": "#FFFFFF",
+                "alignment": "left",
+                "color": "#333333"
             }
         },
         {
             "sectionHeader": "Link",
             "component": "layer-link",
             "settings": {
-                "component": "layer-settings",
-                "values": {
-                    "sectionTitle": "Files",
-                    "showInNavigation": true,
-                    "sectionDescription": "<p>Visit project files page to see documents from all replication studies in this research.&nbsp;</p>",
-                    "sectionLink": "https://osf.io/ezcuj/files/",
-                    "bgColor": "#31708f",
-                    "alignment": "left",
-                    "color": "#ebebeb"
-                },
-                "form": [
-                    {
-                        "type": "settings",
-                        "items": [
-                            {
-                                "type": "checkbox",
-                                "label": "Show in navigation",
-                                "value": "showInNavigation",
-                                "validation": null
-                            },
-                            {
-                                "type": "text",
-                                "label": "Link address",
-                                "value": "sectionLink",
-                                "validation": null
-                            }
-                        ]
-                    },
-                    {
-                        "type": "alignment",
-                        "label": "Alignment",
-                        "value": "alignment",
-                        "options": [
-                            "left",
-                            "center",
-                            "right"
-                        ],
-                        "validation": null
-                    }
-                ]
+                "sectionTitle": "Files",
+                "showInNavigation": true,
+                "sectionDescription": "<p>Visit project files page to see documents from all replication studies in this research.&nbsp;</p>",
+                "sectionLink": "https://osf.io/ezcuj/files/",
+                "bgColor": "#31708f",
+                "alignment": "left",
+                "color": "#ebebeb"
             }
         }
     ]


### PR DESCRIPTION
This PR moves the definition of settings bar for layers from model data (saved with every page) to inside the scope of layer settings component. This way the data for each layer which is the same across all pages does not get saved to database and is taken from the application instead. It is a much more logical way to organize our code. 

This refactor also removes values property from ```layer.settings.values``` and moves it to ```layer.settings``` and does necessary refactors (that's why it touches a lot of files). This is done to remove an unnecessary property. 

template files are updated but this has not been tested with saving to server yet. 